### PR TITLE
Remove react icons context provider from simple icons provider

### DIFF
--- a/src/providers/si/index.js
+++ b/src/providers/si/index.js
@@ -21,11 +21,7 @@ export default function (provider) {
       return {
         provider,
         name: convertFormat(name, options),
-        component: () => (
-          <IconContext.Provider value={{ size: "20px" }}>
-            <Icon />
-          </IconContext.Provider>
-        ),
+        component: () => <Icon />,
         tags: createTags(name, convertFormat),
       };
     });


### PR DESCRIPTION
Since we're using the context provider at the index level [(please see here)](https://github.com/christopherafbjur/sanity-plugin-icon-picker/blob/c8f699aa0b00392388ec9f962e9fd8e770121e22/src/index.js#L103), the context on provider level should be removed.