### PR TITLE
fixes #34, ensure tabs are not shown with a single provider

### DIFF
--- a/src/components/IconPicker.tsx
+++ b/src/components/IconPicker.tsx
@@ -85,16 +85,24 @@ const IconPicker = ({schemaType, value = {}, onChange}: ObjectInputProps) => {
     }
   }
 
-  const showTabs = schemaType.options?.providers?.length > 1
+  const hideTabs = schemaType.options?.providers?.length === 1
 
   return (
     <Card>
-      <IconContext.Provider value={{style: {width: ICON_WIDTH, height: ICON_HEIGHT}}}>
+      <IconContext.Provider value={{ style: { width: ICON_WIDTH, height: ICON_HEIGHT } }}>
         <Menu onClick={handleMenuClick} selected={selected} />
 
         <Popup onClose={closePopup} isOpen={isPopupOpen}>
           <SearchBar value={query} onChange={onQueryChange} />
-          {showTabs ? (
+          {hideTabs ? (
+            <SearchResults
+              results={queryResults}
+              selected={selected}
+              onSelect={setIcon}
+              loading={loading}
+              query={query}
+            />
+          ) : (
             <Tabs options={schemaType.options} onClick={onTabClick}>
               <SearchResults
                 results={queryResults}
@@ -104,14 +112,6 @@ const IconPicker = ({schemaType, value = {}, onChange}: ObjectInputProps) => {
                 query={query}
               />
             </Tabs>
-          ) : (
-            <SearchResults
-              results={queryResults}
-              selected={selected}
-              onSelect={setIcon}
-              loading={loading}
-              query={query}
-            />
           )}
         </Popup>
       </IconContext.Provider>

--- a/src/components/IconPicker.tsx
+++ b/src/components/IconPicker.tsx
@@ -85,6 +85,8 @@ const IconPicker = ({schemaType, value = {}, onChange}: ObjectInputProps) => {
     }
   }
 
+  const showTabs = schemaType.options?.providers?.length > 1
+
   return (
     <Card>
       <IconContext.Provider value={{style: {width: ICON_WIDTH, height: ICON_HEIGHT}}}>
@@ -92,7 +94,17 @@ const IconPicker = ({schemaType, value = {}, onChange}: ObjectInputProps) => {
 
         <Popup onClose={closePopup} isOpen={isPopupOpen}>
           <SearchBar value={query} onChange={onQueryChange} />
-          <Tabs options={schemaType.options} onClick={onTabClick}>
+          {showTabs ? (
+            <Tabs options={schemaType.options} onClick={onTabClick}>
+              <SearchResults
+                results={queryResults}
+                selected={selected}
+                onSelect={setIcon}
+                loading={loading}
+                query={query}
+              />
+            </Tabs>
+          ) : (
             <SearchResults
               results={queryResults}
               selected={selected}
@@ -100,7 +112,7 @@ const IconPicker = ({schemaType, value = {}, onChange}: ObjectInputProps) => {
               loading={loading}
               query={query}
             />
-          </Tabs>
+          )}
         </Popup>
       </IconContext.Provider>
     </Card>


### PR DESCRIPTION
When a single provider is set as an option, tabs should not be displayed. It is confusing to the person using the icon picker to see "Hero Icons" at all, if that is the single provider that they can choose from.

This removes the highlighted section below from being displayed, when only one provider is passed.

<img width="663" alt="Screen Shot 2023-04-02 at 10 41 32 AM" src="https://user-images.githubusercontent.com/649890/229369227-faa7a265-e523-40d6-93d7-197731b9186b.png">
