### PR TITLE
Add support for storing icon SVGs as strings #37

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ Filter out a subset of icons to be used by specifying a filter. A filter can be 
 }
 ```
 
+### Store SVG
+
+If you don't want to dynamically generate the icons in your front-end as described in [this example](#example-1-dynamically-generating-icon), you can opt in to storing the selected SVG icon as a string in your data ([usage example here](#example-2-stored-svg)).
+
+```js
+{
+    title: "Icon",
+    name: "icon",
+    type: "iconPicker",
+    options: {
+        storeSvg: true
+    }
+}
+```
+
 ## Supported Icon Providers
 
 | Provider                | Prefix | Homepage                                       |
@@ -138,6 +153,8 @@ Then refer to the [old documentation](https://github.com/christopherafbjur/sanit
 
 ### How can I consume the data returned from Sanity Studio in my React app?
 
+
+#### Example 1: Dynamically generating icon
 Here's a really simple example of how you could consume the data to render a Font Awesome icon from it. Note that in this example I'm using the option `outputFormat: 'react'` for the icon picker in the studio as mentioned [here](https://github.com/christopherafbjur/sanity-plugin-icon-picker#output-format).
 
 ```js
@@ -158,6 +175,52 @@ export default function App() {
   return (
     <div className="App">
       <Icon />
+    </div>
+  );
+}
+```
+
+#### Example 2: Stored SVG
+If you've opted in to [store SVGs](#store-svg) in your data (`options.storeSvg`), you could present them in various ways:
+
+```js
+// Sanity data mock
+const data = {
+  _type: "iconPicker",
+  name: "alert-circle",
+  provider: "fi",
+  svg:
+    '<svg fill="none" height="1em" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10" /><line x1="12" x2="12" y1="8" y2="12" /><line x1="12" x2="12.01" y1="16" y2="16" /></svg>'
+};
+
+export default function App() {
+  const encodedSvg = encodeURIComponent(data.svg);
+  const imgSrc = `data:image/svg+xml,${encodedSvg}`;
+
+  return (
+    <div className="App">
+      <img src={imgSrc} />
+    </div>
+  );
+}
+```
+
+```js
+import SVG from 'react-inlinesvg';
+
+// Sanity data mock
+const data = {
+  _type: "iconPicker",
+  name: "alert-circle",
+  provider: "fi",
+  svg:
+    '<svg fill="none" height="1em" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><circle cx="12" cy="12" r="10" /><line x1="12" x2="12" y1="8" y2="12" /><line x1="12" x2="12.01" y1="16" y2="16" /></svg>'
+};
+
+export default function App() {
+  return (
+    <div className="App">
+      <SVG src={data.svg} />
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,9 @@
         "@sanity/incompatible-plugin": "^1.0.4",
         "decamelize": "3.2.0",
         "framework7-icons": "^5.0.5",
+        "pretty-format": "^29.5.0",
         "react-icons": "^4.8.0",
+        "react-test-renderer": "^18.2.0",
         "react-virtualized-auto-sizer": "^1.0.5",
         "react-window": "^1.8.6",
         "sanity": "^3"
@@ -21,6 +23,7 @@
         "@sanity/pkg-utils": "^2.2.6",
         "@sanity/plugin-kit": "^3.1.7",
         "@types/react": "^18.0.28",
+        "@types/react-test-renderer": "^18.0.0",
         "@types/react-virtualized-auto-sizer": "^1.0.1",
         "@types/react-window": "^1.8.5",
         "@types/styled-components": "^5.1.26",
@@ -2269,6 +2272,17 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@jest/schemas": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "dependencies": {
+        "@sinclair/typebox": "^0.25.16"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -3915,6 +3929,11 @@
         "rxjs": "^7.8.0"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
+    },
     "node_modules/@tanstack/react-virtual": {
       "version": "3.0.0-beta.29",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.29.tgz",
@@ -4055,6 +4074,15 @@
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
       "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-test-renderer": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz",
+      "integrity": "sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==",
+      "dev": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -10303,6 +10331,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "dependencies": {
+        "@jest/schemas": "^29.4.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/pretty-ms": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
@@ -10631,6 +10683,31 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18",
         "rxjs": "^6.5 || ^7"
+      }
+    },
+    "node_modules/react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "dependencies": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
       }
     },
     "node_modules/react-virtualized-auto-sizer": {
@@ -15553,6 +15630,14 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@jest/schemas": {
+      "version": "29.4.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.3.tgz",
+      "integrity": "sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==",
+      "requires": {
+        "@sinclair/typebox": "^0.25.16"
+      }
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -16699,6 +16784,11 @@
         "rxjs": "^7.8.0"
       }
     },
+    "@sinclair/typebox": {
+      "version": "0.25.24",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.24.tgz",
+      "integrity": "sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ=="
+    },
     "@tanstack/react-virtual": {
       "version": "3.0.0-beta.29",
       "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.0-beta.29.tgz",
@@ -16825,6 +16915,15 @@
       "version": "17.0.3",
       "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
       "integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-18.0.0.tgz",
+      "integrity": "sha512-C7/5FBJ3g3sqUahguGi03O79b8afNeSD6T8/GU50oQrJCU0bVCCGQHaGKUbg2Ce8VQEEqTw8/HiS6lXHHdgkdQ==",
+      "dev": true,
       "requires": {
         "@types/react": "*"
       }
@@ -21418,6 +21517,23 @@
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
       "dev": true
     },
+    "pretty-format": {
+      "version": "29.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
+      "integrity": "sha512-V2mGkI31qdttvTFX7Mt4efOqHXqJWMu4/r66Xh3Z3BwZaPfPJgp6/gbwoujRpPUtfEF6AUUWx3Jim3GCw5g/Qw==",
+      "requires": {
+        "@jest/schemas": "^29.4.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
+        }
+      }
+    },
     "pretty-ms": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-7.0.1.tgz",
@@ -21677,6 +21793,25 @@
       "requires": {
         "observable-callback": "^1.0.2",
         "use-sync-external-store": "^1.2.0"
+      }
+    },
+    "react-shallow-renderer": {
+      "version": "16.15.0",
+      "resolved": "https://registry.npmjs.org/react-shallow-renderer/-/react-shallow-renderer-16.15.0.tgz",
+      "integrity": "sha512-oScf2FqQ9LFVQgA73vr86xl2NaOIX73rh+YFqcOp68CWj56tSfgtGKrEbyhCj0rSijyG9M1CYprTh39fBi5hzA==",
+      "requires": {
+        "object-assign": "^4.1.1",
+        "react-is": "^16.12.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "react-test-renderer": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-18.2.0.tgz",
+      "integrity": "sha512-JWD+aQ0lh2gvh4NM3bBM42Kx+XybOxCpgYK7F8ugAlpaTSnWsX+39Z4XkOykGZAHrjwwTZT3x3KxswVWxHPUqA==",
+      "requires": {
+        "react-is": "^18.2.0",
+        "react-shallow-renderer": "^16.15.0",
+        "scheduler": "^0.23.0"
       }
     },
     "react-virtualized-auto-sizer": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "@sanity/incompatible-plugin": "^1.0.4",
     "decamelize": "3.2.0",
     "framework7-icons": "^5.0.5",
+    "pretty-format": "^29.5.0",
     "react-icons": "^4.8.0",
+    "react-test-renderer": "^18.2.0",
     "react-virtualized-auto-sizer": "^1.0.5",
     "react-window": "^1.8.6",
     "sanity": "^3"
@@ -63,6 +65,7 @@
     "@sanity/pkg-utils": "^2.2.6",
     "@sanity/plugin-kit": "^3.1.7",
     "@types/react": "^18.0.28",
+    "@types/react-test-renderer": "^18.0.0",
     "@types/react-virtualized-auto-sizer": "^1.0.1",
     "@types/react-window": "^1.8.5",
     "@types/styled-components": "^5.1.26",

--- a/src/components/IconPicker.tsx
+++ b/src/components/IconPicker.tsx
@@ -10,6 +10,7 @@ import Menu, {Action, MenuClickCallback} from './Menu'
 import {IconContext} from 'react-icons'
 import {getIcons} from '../utils/icons'
 import {IconObject, IconObjectArray} from '../types'
+import { iconToSvgString } from '../utils/svgs';
 
 function getIconByValue(name: string, icons: IconObjectArray) {
   const found = icons.find((icon) => icon.name === name)
@@ -52,9 +53,10 @@ const IconPicker = ({schemaType, value = {}, onChange}: ObjectInputProps) => {
       }),
       set(icon.name, ['name']),
       set(icon.provider, ['provider']),
+      schemaType.options.storeSvg ? set(iconToSvgString(icon), ['svg']) : unset(['svg'])
     ])
 
-    return setSelected(icon)
+    setSelected(icon)
   }
 
   const openPopup = () => {

--- a/src/utils/svgs.ts
+++ b/src/utils/svgs.ts
@@ -1,0 +1,104 @@
+import format, { plugins } from "pretty-format";
+import renderer from "react-test-renderer";
+import { IconObject } from "../types";
+import type { ReactTestRendererJSON } from "react-test-renderer";
+
+interface ObjectProps {
+  [key: string]: string;
+}
+
+// Reference https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute
+const IGNORED_SVG_ATTRIBUTES = [
+  "attributeName",
+  "attributeType",
+  "baseFrequency",
+  "baseProfile",
+  "calcMode",
+  "clipPathUnits",
+  "contentScriptType",
+  "contentStyleType",
+  "diffuseConstant",
+  "edgeMode",
+  "filterRes",
+  "filterUnits",
+  "glyphRef",
+  "gradientTransform",
+  "gradientUnits",
+  "kernelMatrix",
+  "kernelUnitLength",
+  "keyPoints",
+  "keySplines",
+  "keyTimes",
+  "lengthAdjust",
+  "limitingConeAngle",
+  "markerHeight",
+  "markerUnits",
+  "markerWidth",
+  "maskContentUnits",
+  "maskUnits",
+  "numOctaves",
+  "pathLength",
+  "patternContentUnits",
+  "patternTransform",
+  "patternUnits",
+  "pointsAtX",
+  "pointsAtY",
+  "pointsAtZ",
+  "preserveAlpha",
+  "preserveAspectRatio",
+  "primitiveUnits",
+  "referrerPolicy",
+  "refX",
+  "refY",
+  "repeatCount",
+  "repeatDur",
+  "requiredExtensions",
+  "requiredFeatures",
+  "specularConstant",
+  "specularExponent",
+  "spreadMethod",
+  "startOffset",
+  "stdDeviation",
+  "stitchTiles",
+  "surfaceScale",
+  "systemLanguage",
+  "tableValues",
+  "targetX",
+  "targetY",
+  "textLength",
+  "viewBox",
+  "viewTarget",
+  "xChannelSelector",
+  "yChannelSelector",
+  "zoomAndPan",
+];
+
+const toKebabCase = (key: string) => {
+  return key.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+};
+
+const mapObjectKeys = (obj: ObjectProps) =>
+  Object.entries(obj).reduce((acc: ObjectProps, [key, value]) => {
+    const keyHasIncorrectCasing = !IGNORED_SVG_ATTRIBUTES.includes(key);
+    const newKey = keyHasIncorrectCasing ? toKebabCase(key) : key;
+
+    acc[newKey] = value;
+
+    return acc;
+  }, {});
+
+export const iconToSvgString = (icon: IconObject) => {
+  const component = renderer
+    .create(icon.component())
+    .toJSON() as ReactTestRendererJSON;
+
+  delete component.props.style;
+  
+  component.props = mapObjectKeys(component.props);
+
+  return format(component, {
+    plugins: [plugins.ReactTestComponent],
+    printFunctionName: false,
+    min: true,
+  });
+};


### PR DESCRIPTION
### Description
It's been discussed that front-end bundles are being too large due to the dynamic generation of react-icons and an alternative way of generating the icons by including the SVG in the data.

### Example
The user will simply add an option `storeSvg: true` to their sanity-plugin-icon-picker schema type.
```js
{
        title: 'Icon',
        name: 'icon',
        type: 'iconPicker',
        options: {
          storeSvg: true
        }
}
```

And the studio will store the selected icon as an SVG string in your data:
```json
{
  "icon": {
    "_type": "iconPicker",
    "name": "alert-circle",
    "provider": "fi",
    "svg": "<svg fill=\"none\" height=\"1em\" stroke=\"currentColor\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2\" viewBox=\"0 0 24 24\" width=\"1em\" xmlns=\"http://www.w3.org/2000/svg\"><circle cx=\"12\" cy=\"12\" r=\"10\" /><line x1=\"12\" x2=\"12\" y1=\"8\" y2=\"12\" /><line x1=\"12\" x2=\"12.01\" y1=\"16\" y2=\"16\" /></svg>"
  }
}
```

#37 #18