### PR TITLE
Modify pre-commit hook to run chained to avoid unnecessary execution

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run check-types
-npm run lint
-npm run format
+npm run check-types && npm run lint && npm run format


### PR DESCRIPTION
Minor fix. Even if it works perfectly fine to run the npm scripts without chaining them, each script will run regardless if the previous command returned a non-zero exit code, so it's better to have them chained in order to cancel execution of scripts if one fails.