### PR TITLE
Make preview custom preview options optional

### DIFF
--- a/src/utils/public/utils.ts
+++ b/src/utils/public/utils.ts
@@ -4,7 +4,7 @@ import type { IconObject, IconPickerOptions } from '../../types';
 import type { ReactElement } from 'react';
 
 type Preview = Pick<IconObject, 'provider' | 'name'> & {
-  options: IconPickerOptions;
+  options?: IconPickerOptions;
 };
 // eslint-disable-next-line react/display-name
 export const preview = ({


### PR DESCRIPTION
0ca1e4b7c4b718de07360871dd3f695842a77ad5 adds options to the `preview()` helper function. This PR makes the options optional.